### PR TITLE
Recover from element-not-found scenarios

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/saikrishna321/appium-wait-plugin.git"
+    "url": "git+https://github.com/zcsteele/appium-wait-plugin.git"
   },
   "contributors": [
     {
@@ -28,13 +28,17 @@
     {
       "name": "Srinivasan Sekar",
       "email": "srinivasan.sekar1990@gmail.com"
+    },
+    {
+      "name": "Zachary Steele",
+      "email": "zcsteele@gmail.com"
     }
   ],
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/saikrishna321/appium-wait-plugin/issues"
+    "url": "https://github.com/zcsteele/appium-wait-plugin/issues"
   },
-  "homepage": "https://github.com/saikrishna321/appium-wait-plugin#readme",
+  "homepage": "https://github.com/zcsteele/appium-wait-plugin#readme",
   "dependencies": {
     "async-wait-until": "^2.0.12",
     "axios": "0.27.2",


### PR DESCRIPTION
In cases where Appium is unable to locate an element, the WDA interface responds to Appium with a 404 error.  The current implementation for the wait plugin results in the ORA spinner getting stuck and leaves it running in the Appium server logs indefinitely.

This PR addresses the issue with a couple of changes:
1. The try/catch block around the `waitUntil` call is wrapped in a `while` loop, which restarts the `waitUntil` predicate in cases where an exception is thrown
2.   The calls to start/stop the ORA spinner are moved outside the new while loop, to ensure the spinner is closed once the wait code has run longer than the configured max delay