### PR TITLE
Add a try/catch block to cleanly handle axios errors (404, etc)

### DIFF
--- a/src/element.js
+++ b/src/element.js
@@ -139,16 +139,20 @@ async function elementState(sessionInfo, strategy, selector, driver) {
       multiple: false,
     });
   }
-  const response = await axios.post(
-    `${sessionInfo.baseUrl}session/${sessionInfo.jwProxySession}/element`,
-    postBody,
-    {
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    }
-  );
-  return response.data;
+  try {
+    const response = await axios.post(
+      `${sessionInfo.baseUrl}session/${sessionInfo.jwProxySession}/element`,
+      postBody,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+    return response.data;
+  } catch (e) {
+    return { value: { error: e.message } }
+  }
 }
 
 function _getPluginProperties(sessionId) {


### PR DESCRIPTION
The `element-wait` plugin has an issue where the ora spinner gets stuck in the 'waiting' state if the selector provided is unable to match to an onscreen element.

From my analysis, the root causes tracks back to Axios.  When Appium fails to find an element, the API call responds with a 404 error which Axios processes by throwing an exception.

The solution provided here is as follows:
1. In the `elementState` function, the call to Axios is wrapped in a try/catch block
2. Since the predicate expects `elementState` to respond with an object, the error is returned as `value.error` 